### PR TITLE
Add existing privacy and terms pages to footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+
+const Footer = () => {
+  return (
+    <footer className="site-footer">
+      <div className="container">
+        <div className="row">
+          <div className="col-12 text-center">
+            <ul className="list-inline">
+              <li className="list-inline-item">
+                <Link href="/privacy">Privacy</Link>
+              </li>
+              <li className="list-inline-item">-</li>
+              <li className="list-inline-item">
+                <Link href="/terms">Terms</Link>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import "bootstrap-icons/font/bootstrap-icons.css";
 import "../public/scss/style.scss";
 import type { AppProps } from "next/app";
 import Navbar from "../components/navbar";
+import Footer from "../components/Footer";
 import AppContextProvider from "../contexts/appContextProvider";
 import AppContext from "../contexts/appContext";
 import Head from "next/head";
@@ -21,6 +22,7 @@ const SquareGridApp = ({ Component, pageProps: { ...pageProps } }: AppProps) => 
             </Head>
             {!hideNavbar && <Navbar context={context} />}
             <Component {...pageProps} context={context} />
+            <Footer />
           </>
         )}
       </AppContext.Consumer>

--- a/public/scss/_site-footer.scss
+++ b/public/scss/_site-footer.scss
@@ -64,4 +64,20 @@
 		}
 	}
 
+	.links {
+		display: flex;
+		justify-content: center;
+		list-style: none;
+		padding: 0;
+		li {
+			margin: 0 10px;
+			a {
+				color: $primary;
+				text-decoration: none;
+				&:hover {
+					text-decoration: underline;
+				}
+			}
+		}
+	}
 }

--- a/public/scss/_site-footer.scss
+++ b/public/scss/_site-footer.scss
@@ -1,10 +1,9 @@
 .site-footer {
-	background: #fafafa;
 	font-size: 14px;	
-	color: #888;
+	color: #000;
 	padding: 70px 0;
 	a {
-		color: $primary;
+		color: #000000;
 		position: relative;
 		display: inline-block;
 	}
@@ -29,7 +28,7 @@
 			li {
 				margin-bottom: 10px;
 				a {
-					color: #777;
+					color: #000000;
 				}
 			}
 		}
@@ -72,7 +71,7 @@
 		li {
 			margin: 0 10px;
 			a {
-				color: $primary;
+				color: #000000;
 				text-decoration: none;
 				&:hover {
 					text-decoration: underline;


### PR DESCRIPTION
Fixes #27

Add a footer with privacy and terms links to all pages.

* **Add Footer Component**: Create a new `Footer` component in `components/Footer.tsx` with links to `/privacy` and `/terms` separated by a hyphen.
* **Update _app.tsx**: Import the `Footer` component and add it to the bottom of the layout in `pages/_app.tsx`.
* **Style Footer**: Add styles for the footer with a horizontal list of links in `public/scss/_site-footer.scss`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ourgameltd/squaregrid.web/pull/28?shareId=4090ef50-05b3-47b3-b7ee-87400415b11b).