### PR TITLE
Update link and QR code on UI

### DIFF
--- a/.github/workflows/release-live.yml
+++ b/.github/workflows/release-live.yml
@@ -30,6 +30,7 @@ jobs:
           B2C_CLIENT_SECRET: ${{ secrets.AZURE_AD_B2C_CLIENT_SECRET }}
           NEXT_PUBLIC_MEDIA_ENDPOINT: ${{ vars.NEXT_PUBLIC_MEDIA_ENDPOINT }}
           NEXT_PUBLIC_DOMAIN: ${{ vars.NEXT_PUBLIC_DOMAIN }}
+          NEXT_PUBLIC_SHARE_DOMAIN: http://go.squaregrid.org
 
       - name: Login to Azure
         uses: azure/login@v1
@@ -42,6 +43,7 @@ jobs:
           AZURE_AD_B2C_CLIENT_SECRET: ${{ secrets.AZURE_AD_B2C_CLIENT_SECRET }}
           NEXT_PUBLIC_MEDIA_ENDPOINT: ${{ vars.NEXT_PUBLIC_MEDIA_ENDPOINT }}
           NEXT_PUBLIC_DOMAIN: ${{ vars.NEXT_PUBLIC_DOMAIN }}
+          NEXT_PUBLIC_SHARE_DOMAIN: http://go.squaregrid.org
         run: |
           az staticwebapp appsettings set \
             --name "squaregrid" \
@@ -50,5 +52,5 @@ jobs:
             B2C_CLIENT_ID=017c1045-b0db-4e87-bc13-87d68dce0185 \
             B2C_CLIENT_SECRET=$AZURE_AD_B2C_CLIENT_SECRET \
             NEXT_PUBLIC_MEDIA_ENDPOINT=$NEXT_PUBLIC_MEDIA_ENDPOINT \
-            NEXT_PUBLIC_DOMAIN=$NEXT_PUBLIC_DOMAIN
-
+            NEXT_PUBLIC_DOMAIN=$NEXT_PUBLIC_DOMAIN \
+            NEXT_PUBLIC_SHARE_DOMAIN=$NEXT_PUBLIC_SHARE_DOMAIN

--- a/components/forms/GameForm.tsx
+++ b/components/forms/GameForm.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import QRCode from "qrcode";
 
 const GameForm = ({ game: game, register, errors, imgSrc, setImgSrc }: GameComponentProps) => {
-  const [shareableLinkPrefix, setShareableLinkPrefix] = useState(`${process.env.NEXT_PUBLIC_DOMAIN}/play/`);
+  const [shareableLinkPrefix, setShareableLinkPrefix] = useState(`${process.env.NEXT_PUBLIC_SHARE_DOMAIN}/`);
   const [shareableLink, setShareableLink] = useState("");
 
   const [qrLink, setQrLink] = useState("");

--- a/components/play/SidebarContent.tsx
+++ b/components/play/SidebarContent.tsx
@@ -9,7 +9,7 @@ export interface SidebarContentComponentProps {
 }
 
 const SidebarContent: React.FC<SidebarContentComponentProps> = ({ game }) => {
-  const [shareableLinkPrefix, setShareableLinkPrefix] = useState(`${process.env.NEXT_PUBLIC_DOMAIN}/play/`);
+  const [shareableLinkPrefix, setShareableLinkPrefix] = useState(`${process.env.NEXT_PUBLIC_SHARE_DOMAIN}/`);
   const [shareableLink, setShareableLink] = useState("");
   const [qrLink, setQrLink] = useState("");
   const [linkGroup, setLinkGroup] = useState(game.groupName);


### PR DESCRIPTION
Fixes #33

Update the shareable link and QR code generation to use the new domain from environment variables.

* **GameForm.tsx**
  - Update `shareableLinkPrefix` to use `NEXT_PUBLIC_SHARE_DOMAIN` environment variable.
  - Remove '/play' from the shareable link prefix.

* **SidebarContent.tsx**
  - Update `shareableLinkPrefix` to use `NEXT_PUBLIC_SHARE_DOMAIN` environment variable.
  - Remove '/play' from the shareable link prefix.

* **release-live.yml**
  - Add `NEXT_PUBLIC_SHARE_DOMAIN` environment variable to the `env` section.
  - Add `NEXT_PUBLIC_SHARE_DOMAIN` environment variable to the `az staticwebapp appsettings set` command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ourgameltd/squaregrid.web/pull/34?shareId=f46515b2-785d-4186-846a-c9c93515387d).